### PR TITLE
[refactor] 라운드 참여 관련 API 수정

### DIFF
--- a/STORM/controller/roundController.js
+++ b/STORM/controller/roundController.js
@@ -39,15 +39,14 @@ module.exports = {
 
   //라운드 정보 출력
   roundInfo: async (req, res) => {
-    const project_idx = req.params.project_idx;
+    const round_idx = req.params.round_idx;
 
-    if (!project_idx) {
+    if (!round_idx) {
       return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.ROUND_INFO_FAIL));
     }
 
-    const result = await RoundDao.roundInfo(project_idx);
+    const result = await RoundDao.roundInfo(round_idx);
     return res.status(statusCode.OK).send(util.success(statusCode.OK, resMessage.ROUND_INFO_SUCCESS, {
-      "round_idx": result[0].round_idx,
       "round_number": result[0].round_number,
       "round_purpose": result[0].round_purpose,
       "round_time": result[0].round_time

--- a/STORM/controller/roundController.js
+++ b/STORM/controller/roundController.js
@@ -4,11 +4,11 @@ const resMessage = require('../modules/responseMessage');
 const RoundDao = require('../dao/round');
 
 module.exports = {
+
   //라운드 카운트 정보 반환(count보다 +1한 수를 반환해야 함)
   roundCount: async (req, res) => {
 
     const project_idx = req.params.project_idx;
-
     if (!project_idx) {
       return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.ROUND_COUNT_FAIL));
     }
@@ -23,14 +23,18 @@ module.exports = {
 
   //라운드 정보 새로 추가
   roundSetting: async (req, res) => {
-    const { project_idx, round_purpose, round_time } = req.body;
 
-    if (!project_idx || !round_purpose || !round_time) {
+    const { user_idx, project_idx, round_purpose, round_time } = req.body;
+    if (!user_idx || !project_idx || !round_purpose || !round_time) {
       return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, resMessage.ROUND_SETTING_FAIL));
     }
+
     const result = await RoundDao.roundSetting(project_idx, round_purpose, round_time);
 
-    return res.status(statusCode.OK).send(util.success(statusCode.OK, resMessage.ROUND_SETTING_SUCCESS, result));
+    //라운드 추가시 해당 라운드에 자동으로 참여하도록
+    await RoundDao.roundEnter(user_idx, result);
+
+    return res.status(statusCode.OK).send(util.success(statusCode.OK, resMessage.ROUND_SETTING_SUCCESS));
   },
 
   //라운드 정보 출력

--- a/STORM/dao/round.js
+++ b/STORM/dao/round.js
@@ -47,6 +47,19 @@ module.exports = {
         }
     },
 
+    //(2라운드 이상부터) project_idx로 가장 최근의 round_idx 찾기
+    checkRoundIdx: async (project_idx) => {
+        const query = `SELECT round_idx FROM round WHERE project_idx = ${project_idx}`
+
+        try {
+            const result = await pool.queryParam(query);
+            return result[result.length-1]["round_idx"];
+        } catch (err) {
+            console.log('checkRoundIdx ERROR : ', err);
+            throw err;
+        }
+    },
+
     //project_idx를 받았을 때 project_idx로 round 수 반환해서 round_idx, round_number, round_purpose, round_time를 반환
     roundInfo: async (project_idx) => {
         const query1 = `SELECT COUNT(*) FROM round WHERE project_idx = ${project_idx}`

--- a/STORM/dao/round.js
+++ b/STORM/dao/round.js
@@ -60,24 +60,6 @@ module.exports = {
         }
     },
 
-    //project_idx를 받았을 때 project_idx로 round 수 반환해서 round_idx, round_number, round_purpose, round_time를 반환
-    roundInfo: async (project_idx) => {
-        const query1 = `SELECT COUNT(*) FROM round WHERE project_idx = ${project_idx}`
-
-        try {
-            const round_count = await pool.queryParam(query1);
-            const round_number = round_count[0]["COUNT(*)"];
-
-            const fields = `round_idx, round_number, round_purpose, round_time`;
-            const query2 = `SELECT ${fields} FROM round WHERE project_idx = ${project_idx} AND round_number = ${round_number}`
-            const result = await pool.queryParam(query2);
-            return result;
-        } catch (err) {
-            console.log('roundInfo ERROR : ', err);
-            throw err;
-        }
-    },
-
     //user_idx, round_idx를 받았을 때 round_participant에 새로운 row 추가
     roundEnter: async (user_idx, round_idx) => {
         const fields = `user_idx, round_idx`;
@@ -90,6 +72,20 @@ module.exports = {
             return result;
         } catch (err) {
             console.log('roundEnter ERROR : ', err);
+            throw err;
+        }
+    },
+
+    //round_idx 받았을 때 round_idx, round_number, round_purpose, round_time를 반환
+    roundInfo: async (round_idx) => {
+        const fields = `round_number, round_purpose, round_time`;
+        const query = `SELECT ${fields} FROM round WHERE round_idx = ${round_idx}`
+
+        try {
+            const result = await pool.queryParam(query);
+            return result;
+        } catch (err) {
+            console.log('roundInfo ERROR : ', err);
             throw err;
         }
     },
@@ -206,6 +202,7 @@ module.exports = {
         }
     },
 
+    //중복 참여 방지
     testErrRound: async(user_idx, round_idx) => {
         const query = `SELECT COUNT(*) FROM round_participant rp WHERE rp.user_idx = ${user_idx} AND rp.round_idx = ${round_idx}`;
         try{

--- a/STORM/routes/round.js
+++ b/STORM/routes/round.js
@@ -5,7 +5,7 @@ const roundController = require('../controller/roundController');
 router.get("/count/:project_idx", roundController.roundCount);
 router.post("/setting", roundController.roundSetting);
 router.get("/info/:project_idx", roundController.roundInfo);
-router.post("/enter", roundController.roundEnter);
+router.post("/enter", roundController.nextRoundEnter);
 router.delete("/leave/:user_idx/:round_idx", roundController.roundLeave);
 router.get("/memberList/:project_idx/:round_idx", roundController.roundParticipant);
 router.get("/cardList/:project_idx/:round_idx", roundController.roundCardList);

--- a/STORM/routes/round.js
+++ b/STORM/routes/round.js
@@ -4,7 +4,7 @@ const roundController = require('../controller/roundController');
 
 router.get("/count/:project_idx", roundController.roundCount);
 router.post("/setting", roundController.roundSetting);
-router.get("/info/:project_idx", roundController.roundInfo);
+router.get("/info/:round_idx", roundController.roundInfo);
 router.post("/enter", roundController.nextRoundEnter);
 router.delete("/leave/:user_idx/:round_idx", roundController.roundLeave);
 router.get("/memberList/:project_idx/:round_idx", roundController.roundParticipant);


### PR DESCRIPTION
HOST
* 라운드 생성 시 -> 해당하는 라운드 참여자 목록에 추가됨

MEMBER
* (2라운드 이상 진행 시) -> project_idx로 round_idx를 반환받아서 해당 라운드 참여자 목록에 추가됨

이외
* round_idx를 이제 클라측에서 먼저 받을 수 있기 때문에 해당 라운드 정보를 round_idx로 반환받도록 수정